### PR TITLE
Moved list reset to right location

### DIFF
--- a/main/management/commands/run_thug.py
+++ b/main/management/commands/run_thug.py
@@ -190,16 +190,16 @@ class Command(BaseCommand):
                 for key in to_delete:
                     del sample[key]
 
-            to_delete = []
             for exploit in exploits:
+                to_delete = []
                 for key, value in exploit.iteritems():
                     if isinstance(value, ObjectId):
                         to_delete.append(key)
                 for key in to_delete:
                     del exploit[key]
 
-            to_delete = []
             for certificate in certificates:
+                to_delete = []
                 for key, value in certificate.iteritems():
                     if isinstance(value, ObjectId):
                         to_delete.append(key)

--- a/main/utils.py
+++ b/main/utils.py
@@ -18,6 +18,7 @@
 #
 # Author:   Tarun Kumar <reach.tarun.here@gmail.com>
 #
+from bson import ObjectId
 
 def is_text(mime):
     if mime.startswith('text/'):
@@ -27,3 +28,14 @@ def is_text(mime):
         return True
 
     return False
+
+
+def clone_without_object_ids(aDict, key_exclude_filter=None):
+    if isinstance(aDict, dict):
+        # if key_exclude_filter is defined use it to filter
+        if key_exclude_filter:
+            return {key :value for key, value in aDict.iteritems() if not isinstance(value, ObjectId) and key != key_exclude_filter}
+        # otherwise just remove ObjectId keys
+        return {key :value for key, value in aDict.iteritems() if not isinstance(value, ObjectId)}
+    # if argument is not a dict just return it as it was
+    return aDict


### PR DESCRIPTION
Moved the reset of to_delete list inside of make_flat_tree function to avoid unwanted crash when there are more than one exploit or certificate.

This is to avoid this error:
```
Traceback (most recent call last):
  File "/xxx/rumal_back/main/management/commands/run_thug.py", line 364, in handle
    task.object_id = self.run_task(task)
  File "/xxx/rumal_back/main/management/commands/run_thug.py", line 339, in run_task
    analysis = self.make_flat_tree(analysis,r.group(1))
  File "/xxx/rumal_back/main/management/commands/run_thug.py", line 207, in make_flat_tree
    del certificate[key]
KeyError: u'url_id'
```
Occurred when trying to scan `https://it.wikipedia.org/wiki/Pagina_principale`