### PR TITLE
Temporary fix for rumal_docker

### DIFF
--- a/main/management/commands/run_thug.py
+++ b/main/management/commands/run_thug.py
@@ -295,7 +295,7 @@ class Command(BaseCommand):
         logger.debug("[{}] Will run command: {}".format(task.id, " ".join(args)))
         p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         signal.signal(signal.SIGALRM, timeout_handler)
-        signal.alarm(5*60) # 5 minutes
+        signal.alarm(10*60) # 10 minutes
         try:
             stdout, stderr = p.communicate()
             signal.alarm(0)  # reset the alarm

--- a/main/management/commands/run_thug.py
+++ b/main/management/commands/run_thug.py
@@ -207,6 +207,7 @@ class Command(BaseCommand):
     def run_task(self, task):
         # Initialize args list for docker
         args = [
+            "unbuffer",
             "/usr/bin/sudo", "/usr/bin/docker", "run",
             "--rm",
             "-a", "stdin",

--- a/main/management/commands/run_thug.py
+++ b/main/management/commands/run_thug.py
@@ -213,7 +213,7 @@ class Command(BaseCommand):
             "-a", "stdin",
             "-a", "stdout",
             "-a", "stderr",
-            "-t",
+            "-it",
             "pdelsante/thug-dockerfile",
             "/usr/bin/python", "/opt/thug/src/thug.py"
             ]


### PR DESCRIPTION
Adding buffer to command line argument for running thug. Temporary use with rumal_docker until docker-py is used.
Timer on scan is set to 10mn instead of 5.  