### PR TITLE
Fix Issue #12

### DIFF
--- a/main/management/commands/consumer.py
+++ b/main/management/commands/consumer.py
@@ -77,6 +77,9 @@ class Command(BaseCommand):
         frontend_id = str(body['frontend_id'])
         logger.debug("Task received {}".format(frontend_id))
 
+        #  Tasks are unique. If they want to be rerun frontend needs to send them again.
+        [x.delete() for x in Task.objects.filter(frontend_id=frontend_id)]
+
         task_dict = [{"model": "main.task",
                       "fields": body
                       }]

--- a/main/management/commands/consumer.py
+++ b/main/management/commands/consumer.py
@@ -10,7 +10,8 @@ import gridfs
 import time
 
 from main.models import settings, Task
-from main.utils import DownloadError, Encoder, is_text
+from main.utils import DownloadError, Encoder, is_text, STATUS_COMPLETED, STATUS_NEW, STATUS_PROCESSING, STATUS_FAILED,\
+    NEW_SCAN_TASK, RPC_PORT, PRIVATE_QUEUE, PRIVATE_HOST, ANY_QUEUE
 
 from bson import json_util
 import json
@@ -22,24 +23,12 @@ import ConfigParser
 import os
 import threading
 
-RPC_PORT = 5672
-ANY_QUEUE = 'any_queue'
-PRIVATE_QUEUE = 'private_queue'
-PRIVATE_HOST = '0.0.0.0'
 
 config = ConfigParser.ConfigParser()
 config.read(os.path.join(settings.BASE_DIR, "conf", "backend.conf"))
 BACKEND_HOST = config.get('backend', 'host', 'localhost')  # host of master backend where any queue is located
 IS_BACKEND_MASTER = bool(config.get('backend', 'is_master', 'True'))  # master backend should define the any queue
 
-#  tasks
-NEW_SCAN_TASK = 1
-
-#  task status
-STATUS_NEW = 0
-STATUS_PROCESSING = 1
-STATUS_FAILED = 2
-STATUS_COMPLETED = 3
 
 logger = logging.getLogger(__name__)
 

--- a/main/management/commands/run_thug.py
+++ b/main/management/commands/run_thug.py
@@ -34,15 +34,11 @@ from urlparse import urlparse
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from main.models import Task
-from main.utils import clone_without_object_ids
+from main.utils import clone_without_object_ids, STATUS_PROCESSING, STATUS_FAILED, STATUS_NEW, STATUS_COMPLETED
 
 import pymongo
 from bson import ObjectId
 
-STATUS_NEW = 0
-STATUS_PROCESSING = 1
-STATUS_FAILED = 2
-STATUS_COMPLETED = 3
 
 client = pymongo.MongoClient()
 db = client.thug

--- a/main/models.py
+++ b/main/models.py
@@ -12,11 +12,9 @@ from datetime import datetime
 from django.conf import settings
 from django.db import models
 from django.contrib.auth.models import User
+from main.utils import STATUS_NEW, STATUS_COMPLETED, STATUS_FAILED, STATUS_PROCESSING
 
-STATUS_NEW = 0
-STATUS_PROCESSING = 1
-STATUS_FAILED = 2
-STATUS_COMPLETED = 3
+
 STATUS_CHOICES = (
     (STATUS_NEW, 'New'),
     (STATUS_PROCESSING, 'Processing'),

--- a/main/utils.py
+++ b/main/utils.py
@@ -22,6 +22,22 @@ from bson import ObjectId
 import json
 
 
+#  task status
+STATUS_NEW = 0
+STATUS_PROCESSING = 1
+STATUS_FAILED = 2
+STATUS_COMPLETED = 3
+
+#  tasks
+NEW_SCAN_TASK = 1
+
+# Rabbit settings
+RPC_PORT = 5672
+ANY_QUEUE = 'any_queue'
+PRIVATE_QUEUE = 'private_queue'
+PRIVATE_HOST = '0.0.0.0'
+
+
 class DownloadError(Exception):
     pass
 


### PR DESCRIPTION
Fix for issue #12. Moving Task status and Rabbit settings to utils.py.
Backend tasks are unique, if task is resent by frontend, backend removes previously stored value (for failed tasks).