### PR TITLE
Remove sudo from running Thug in docker

### DIFF
--- a/conf/backend.conf
+++ b/conf/backend.conf
@@ -1,3 +1,3 @@
 [backend]
 host = localhost
-is_master = true
+is_master = True

--- a/main/management/commands/consumer.py
+++ b/main/management/commands/consumer.py
@@ -22,12 +22,16 @@ import hexdump
 import ConfigParser
 import os
 import threading
+import ast
 
 
 config = ConfigParser.ConfigParser()
 config.read(os.path.join(settings.BASE_DIR, "conf", "backend.conf"))
 BACKEND_HOST = config.get('backend', 'host', 'localhost')  # host of master backend where any queue is located
-IS_BACKEND_MASTER = bool(config.get('backend', 'is_master', 'True'))  # master backend should define the any queue
+try:
+    IS_BACKEND_MASTER = ast.literal_eval(config.get('backend', 'is_master', 'True'))  # master backend should define the any queue
+except ValueError:
+    IS_BACKEND_MASTER = True
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Sudo can still be used by adding it in the config file, but by default it is not used.
Consumer is_master is now properly translated to boolean from the config file.